### PR TITLE
bug correction: book import command sets book depth incorrectly

### DIFF
--- a/src/book.c
+++ b/src/book.c
@@ -1524,12 +1524,12 @@ void book_import(Book *book, const char *file)
 		}
 		bprint("importing book from %s... %d positions", file, book->n_nodes);
 
-		book->options.n_empties = 0;
+		book->options.n_empties = 60;
 		book->options.level = 0;
 		foreach_position(p, a, book) {
 			n_empties = board_count_empties(p->board);
 			if (p->level > book->options.level) book->options.level = p->level;
-			if (n_empties > book->options.n_empties) book->options.n_empties = n_empties;
+			if (n_empties < book->options.n_empties) book->options.n_empties = n_empties;
 		}
 
 		random_seed(book->random, real_clock());


### PR DESCRIPTION
I found a bug related to "book import" command.
"book import" command sets book depth to 1. I fixed it so that it sets book depth to the maximum depth of imported positions.

I am looking forward to seeing the next release of Edax.