### PR TITLE
remove extraneous unary operator+

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -1153,7 +1153,7 @@ bool play_force_go(Play *play, Move *move)
 		board_unique(play->board, unique);
 		if (board_equal(unique, play->force.unique + play->force.i_move)) {
 			for (s = 1; s < 8; ++s) {
-				board_symetry(play->force.real +  + play->force.i_move, s, sym);
+				board_symetry(play->force.real + play->force.i_move, s, sym);
 				if (board_equal(play->board, sym)) {
 					x = symetry(play->force.move[play->force.i_move].x, s);
 					board_get_move(play->board, x, move);


### PR DESCRIPTION
harmless, but it doesn't really belong there.