### PR TITLE
have COMP=gcc-old use CC=gcc, not CC=gcc-old

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,11 @@ ifeq ($(OS),win)
 endif
 
 ifeq ($(CC),cc)
+ifeq ($(COMP),gcc-old)
+	CC = gcc
+else
 	CC = $(COMP)
+endif
 endif
 
 


### PR DESCRIPTION
The `CC = $(COMP)` wasn't intended for `gcc-old`, it seems.

I can get around it by explicitly specifying `COMP=gcc-old` _and_ `CC=gcc` on the command line, but that shouldn't be necessary.