### PR TITLE
fix bug in ywbc.c

### DIFF
--- a/src/ybwc.c
+++ b/src/ybwc.c
@@ -573,7 +573,7 @@ void task_stack_init(TaskStack *stack, const int n)
 		if (stack->task == NULL) {
 			fatal_error("Cannot allocate an array of %d tasks\n", stack->n);
 		}
-		if (stack->stask == NULL) {
+		if (stack->stack == NULL) {
 			fatal_error("Cannot allocate a stack of %d entries\n", stack->n);
 		}
 


### PR DESCRIPTION
```
gcc -std=c99 -pedantic -W -Wall -Wextra -pipe -D_GNU_SOURCE=1 -Ofast -flto -DNDEBUG -m64 -march=native -DUSE_GAS_X64 -DPOPCOUNT -DHAS_CPU_64 -DLIB_BUILD -fPIC -shared all.c -o ../bin/libedax.so -lm -lrt -lpthread
In file included from all.c:24:0:
ybwc.c: In function ‘task_stack_init’:
ybwc.c:576:14: error: ‘TaskStack {aka struct TaskStack}’ has no member named ‘stask’; did you mean ‘task’?
   if (stack->stask == NULL) {
              ^~~~~
              task
```

fix this bug and resolve https://github.com/abulmo/edax-reversi/issues/15