### PR TITLE
CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,38 @@
+name: build
+
+on:
+  pull_request:
+    paths: ['src/**', 'include/**', '.github/workflows/build.yaml']
+  push:
+    branches: [ master ]
+    paths: ['src/**', 'include/**', '.github/workflows/build.yaml']
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false # We want results from all OSes even if one fails.
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            build_command: make build ARCH=x64-modern COMP=gcc OS=linux
+          - os: windows-latest
+            build_command: make build ARCH=x64 COMP=gcc OS=windows
+          - os: macos-latest
+            build_command: make build ARCH=x64-modern COMP=gcc OS=osx
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: build
+      run: |-
+        mkdir -p bin
+        cd src
+        ${{ matrix.build_command }}
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifact_${{ runner.os }}
+        path: bin


### PR DESCRIPTION
To maintain stability of edax-reversi, I add CI.
If you like, merge this. (probably, you have to setup on https://github.com/abulmo/edax-reversi/settings/actions ..?)

For now, CI fails because there is a bug(https://github.com/abulmo/edax-reversi/pull/16).
After that PR is merged, I update this branch and CI will pass.


sample output: https://github.com/sensuikan1973/edax-reversi/pull/6
![image](https://user-images.githubusercontent.com/23427957/106367728-fcec2000-6387-11eb-86e6-a3652392075e.png)