### PR TITLE
KNC compiling option. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ cd ..
 ./bin/mEdax
 ```
 
+### Compiling for Intel Xeon Phi x100 (Knights Corner)
+Requirement: 
+- icc version 17.0.2 from Intel Parallel Stuido XE 2017 (or any versions after 2016u4 and before 2018, need to have '-mmic' option).
+make the source code with 'make build ARCH=k1om COMP=icc'
+
 ### docker
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ cd ..
 
 ### Compiling for Intel Xeon Phi x100 (Knights Corner)
 Requirement: 
-- icc version 17.0.2 from Intel Parallel Stuido XE 2017 (or any versions after 2016u4 and before 2018, need to have '-mmic' option).
-make the source code with 'make build ARCH=k1om COMP=icc'
+- icc version 17.0.2 from Intel Parallel Stuido XE 2017 (or any versions after 2016u4 and before 2018, need to have '''sh -mmic''' option).
+make the source code with '''sh make build ARCH=k1om COMP=icc'''
 
 ### docker
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ cd ..
 ### Compiling for Intel Xeon Phi x100 (Knights Corner)
 Requirement: 
 - icc version 17.0.2 from Intel Parallel Stuido XE 2017 (or any versions after 2016u4 and before 2018, need to have "-mmic" option).
-make the source code with
+
+Then compile the source code with
 ```sh
 make build ARCH=k1om COMP=icc
 ```

--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ cd ..
 
 ### Compiling for Intel Xeon Phi x100 (Knights Corner)
 Requirement: 
-- icc version 17.0.2 from Intel Parallel Stuido XE 2017 (or any versions after 2016u4 and before 2018, need to have '''sh -mmic''' option).
-make the source code with '''sh make build ARCH=k1om COMP=icc'''
+- icc version 17.0.2 from Intel Parallel Stuido XE 2017 (or any versions after 2016u4 and before 2018, need to have "-mmic" option).
+make the source code with
+```sh
+make build ARCH=k1om COMP=icc
+```
 
 ### docker
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -197,6 +197,9 @@ ifeq ($(COMP),icc)
 	ifeq ($(ARCH),x86)
 		CFLAGS += -m32 -DUSE_GAS_X86
 	endif
+	ifeq ($(ARCH),k1om)
+		CFLAGS += -mmic --static
+	endif
 endif
 
 #pcc
@@ -310,6 +313,7 @@ help:
 	@echo " x86          x86"
 	@echo " ARM          ARM v5 & up"
 	@echo " ARMv7        ARM v7-a"
+	@echo " k1om         Intel Xeon Phi x100 (Knight Corner)"
 	@echo ""
 	@echo "Compilers:"
 	@echo "   gcc        GNU C compiler version >= 4.6"


### PR DESCRIPTION
Adding an option for k1om architechture that was used by Intel Xeon Phi x100 (Knights Corner) Coprocessor series. 
![image](https://github.com/abulmo/edax-reversi/assets/16624643/a2ce4701-97ec-493a-be12-26c0da282758)
