### PR TITLE
point broken link for standardized string format to archive.org

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -122,7 +122,7 @@ void board_swap_players(Board *board)
 /**
  * @brief Set a board from a string description.
  *
- * Read a standardized string (See http://www.nada.kth.se/~gunnar/download2.html
+ * Read a standardized string (See https://web.archive.org/web/20040615001419/https://www.nada.kth.se/~gunnar/download2.html
  * for details) and translate it into our internal Board structure.
  *
  * @param board the board to set


### PR DESCRIPTION
I noticed this link was broken, there may be a better reference but the archive.org "wayback machine" is probably the simplest.