### PR TITLE
Make the Docker image runnable out of the box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,34 @@
-# simple sample
+FROM gcc:13-bookworm
 
-FROM gcc:4.9
+WORKDIR /opt/edax
 
 RUN apt-get update && \
-    apt-get install make && \
-    apt-get install p7zip-full
+    apt-get install -y --no-install-recommends \
+        make \
+        clang \
+        p7zip-full \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY src /opt/edax/src
+COPY problem /opt/edax/problem
+COPY LICENSE /opt/edax/LICENSE
+
+RUN set -eux; \
+    mkdir -p /opt/edax/bin; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      x86_64|amd64) EDAX_ARCH='x86-64-v3' ;; \
+      aarch64|arm64) EDAX_ARCH='armv8.5-a' ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    cd /opt/edax/src; \
+    make build ARCH="$EDAX_ARCH" COMP=clang OS=linux; \
+    cd /opt/edax; \
+    curl -fL -o eval.7z https://github.com/abulmo/edax-reversi/releases/download/v4.4/eval.7z; \
+    7z x -y eval.7z; \
+    rm -f eval.7z; \
+    printf '#!/bin/sh\nset -eu\nexec /opt/edax/bin/lEdax-%s "$@"\n' "$EDAX_ARCH" > /usr/local/bin/edax; \
+    chmod +x /usr/local/bin/edax
+
+ENTRYPOINT ["/usr/local/bin/edax"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# simple sample
 FROM gcc:13-bookworm
 
 WORKDIR /opt/edax

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 COPY src /opt/edax/src
-COPY problem /opt/edax/problem
 COPY LICENSE /opt/edax/LICENSE
 
 RUN set -eux; \

--- a/README.md
+++ b/README.md
@@ -30,18 +30,7 @@ cd ..
 
 ```sh
 docker build . -t edax
-docker run --name "edax" -v "$(pwd)/:/home/edax/" -it edax
-
-cd /home/edax/
-mkdir -p bin
-cd src
-make build ARCH=x86-64-v3 COMP=clang OS=linux
-
-cd ..
-curl -OL https://github.com/abulmo/edax-reversi/releases/download/v4.4/eval.7z # e.g. use v4.4 eval.dat
-7z x eval.7z
-
-./bin/lEdax-x64
+docker run --rm -it edax
 ```
 
 ## Document


### PR DESCRIPTION
# Summary

This PR updates the sample Docker setup so Edax can be built and run directly from the image.

Previously, the Docker instructions required several manual steps after `docker run`, including building Edax inside the container, downloading the evaluation data, extracting it, and launching the binary manually.

With this change, the Docker image becomes runnable out of the box:

```sh
docker build . -t edax
docker run --rm -it edax
```

# Changes

- update the Docker base image from `gcc:4.9` to `gcc:13-bookworm`
- install required tools for the documented Docker workflow:
  - `make`
  - `clang`
  - `curl`
  - `p7zip-full`
- build Edax during `docker build`
- download and extract the evaluation data during image build
- add an entrypoint so the container starts Edax directly
- simplify the README Docker instructions accordingly
- remove the unused `problem` files from the Docker image
- restore the original `# simple sample` comment in the Dockerfile

# Why

The previous Docker setup no longer worked as documented:

- the old base image was outdated
- the documented workflow depended on tools that were not installed in the image
- the container was not directly runnable and required several manual steps after startup

This PR keeps the Dockerfile as a simple sample, while making the documented Docker flow reproducible and immediately usable.

# Result

After this change, users can start Edax with:

```sh
docker build . -t edax
docker run --rm -it edax
```

# Notes

- the Docker image now includes only the files needed to build and run Edax interactively
- the `problem` directory was excluded because it contains solver problem data and is not required for normal interactive play
